### PR TITLE
modify to use go-logger & wait the execution time of HD44780

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ func main() {
 }
 ```
 
+Tutorial
+--------
+
+In its turn, go-hd44780 use [go-logger](https://github.com/d2r2/go-logger) library to output debug and other notification's lines which produce all necessary levels of logging. You can manage what level of verbosity you would like to see, by adding call:
+```go
+// Uncomment/comment next line to suppress/increase verbosity of output
+logger.ChangePackageLogLevel("hd44780", logger.InfoLevel)
+```
+Once you put this call, it will decrease verbosity from default "Debug" up to next "Info" level, reducing the number of low-level console outputs that occur during interaction with the I2C bus. Please, find examples in corresponding I2C-driven sensors among my projects.
+
 Getting help
 ------------
 

--- a/lcd.go
+++ b/lcd.go
@@ -116,7 +116,10 @@ func (this *Lcd) writeDataWithStrobe(data byte) error {
 		data |= PIN_BACKLIGHT
 	}
 	seq := []rawData{
-		{data, 0}, // send data
+		// The execution time to Write CGRAM or DDRAM:
+		// - 37 + 4 microseconds (when fcp = 270 kHz)
+		// - 40 + 4.32 microseconds (when fcp = 250 kHz)
+		{data, 50 * 1000 * time.Nanosecond},     // send data
 		{data | PIN_EN, 200 * time.Microsecond}, // set strobe
 		{data, 30 * time.Microsecond},           // reset strobe
 	}
@@ -197,7 +200,7 @@ func (this *Lcd) splitText(text string, options ShowOptions) []string {
 
 func (this *Lcd) ShowMessage(text string, options ShowOptions) error {
 	lines := this.splitText(text, options)
-	log.Debug("Output: %v\n", lines)
+	lg.Debugf("Output: %v\n", lines)
 	startLine, endLine := this.getLineRange(options)
 	i := 0
 	for {

--- a/logger.go
+++ b/logger.go
@@ -1,41 +1,10 @@
 package hd44780
 
-import (
-	"os"
+import logger "github.com/d2r2/go-logger"
 
-	"github.com/op/go-logging"
+// You can manage verbosity of log output
+// in the package by changing last parameter value.
+var lg = logger.NewPackageLogger("hd44780",
+	logger.DebugLevel,
+	// logger.InfoLevel,
 )
-
-// Comment INFO and uncomment DEBUG if you want detail debug output in library.
-var log *logging.Logger = buildLogger("hd44780",
-	//	logging.DEBUG,
-	logging.INFO,
-)
-
-var terminalBackend logging.LeveledBackend = nil
-
-func buildLogger(module string, level logging.Level) *logging.Logger {
-	// Set the backends to be used.
-	if terminalBackend == nil {
-		// Everything except the message has a custom color
-		// which is dependent on the log level. Many fields have a custom output
-		// formatting too, eg. the time returns the hour down to the milli second.
-		var format = logging.MustStringFormatter(
-			"%{time:2006-01-02T15:04:05.000} [%{module}] " +
-				"%{color}%{level:.4s}%{color:reset}  %{message}",
-		)
-		// Create backend for os.Stderr.
-		var backend logging.Backend = logging.NewLogBackend(os.Stderr, "", 0)
-
-		// For messages written to backend we want to add some additional
-		// information to the output, including the used log level and the name of
-		// the function.
-		var backendFormatter logging.Backend = logging.NewBackendFormatter(backend, format)
-		var backendLeveled logging.LeveledBackend = logging.AddModuleLevel(backendFormatter)
-		terminalBackend = backendLeveled
-		logging.SetBackend(terminalBackend)
-	}
-	log := logging.MustGetLogger(module)
-	terminalBackend.SetLevel(level, module)
-	return log
-}


### PR DESCRIPTION
Dear Mr. d2r2

Thank you very much to release go-hd44780 to GitHub.
I fixed to use your go-logger for convienient. And, I set the execution time to write to DDRAM in DataWithStrobe().

If you're okay, please use this fix.

Regards,
Quanocchi